### PR TITLE
feat: repo-driven views — /:user/:project/map renders any GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ matrix libraries (empty scaffolds in legacy), `angularfire2` / Firebase
 See `_legacy/` for the original Angular 6 source and `CLAUDE.md` for porting
 notes.
 
+## Repo-driven views
+
+Any public GitHub repo with a `geocontext.json` at its root can be rendered
+by GeoContext directly — no fork, no build:
+
+```
+<domain>/<user>/<project>/map
+<domain>/<user>/<project>/map?branch=<ref>&path=<file>
+```
+
+The route loads the config from
+`https://cdn.jsdelivr.net/gh/<user>/<project>@<branch>/<path>` (defaults
+`HEAD` and `geocontext.json`). Datasource references inside the config are
+rewritten by `GcxCoreService.resolveAssetUrl`:
+
+- Absolute URLs pass through.
+- `/<user>/<project>/assets/<file>` (with optional `@<branch>` after project)
+  resolves to that repo's asset on jsdelivr — works across repos.
+- `/assets/<file>` while in repo mode resolves to the *current* repo's
+  matching asset, so existing JSON written for local mode keeps working.
+
+`assets` is reserved at the workspace root (it's not a valid GitHub
+username), so `/<user>/<project>/map` and `/assets/<…>` never collide.
+
 ## Publishing and consuming packages
 
 All libraries publish to **GitHub Packages** under `@openhistorymap/*`

--- a/projects/gcx-core/src/lib/gcx-core.service.ts
+++ b/projects/gcx-core/src/lib/gcx-core.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 
 export const GCX_CORE_FILE = '/assets/gcx.json';
+export const GCX_JSDELIVR_BASE = 'https://cdn.jsdelivr.net/gh';
 
 export interface GcxConfig {
   title?: string;
@@ -17,14 +18,30 @@ export interface GcxConfig {
   [k: string]: any;
 }
 
+/** Identifies a public GitHub repo and which `geocontext.json` to load from it. */
+export interface GcxRepoSource {
+  user: string;
+  project: string;
+  branch?: string;
+  path?: string;
+}
+
+/** Either a plain URL (legacy /assets/gcx.json mode) or a repo descriptor. */
+export type GcxLoadSource = string | GcxRepoSource;
+
 @Injectable({ providedIn: 'root' })
 export class GcxCoreService {
   private readonly http = inject(HttpClient);
 
   readonly sidebarOpen = signal(false);
+  readonly currentRepo = signal<GcxRepoSource | null>(null);
 
-  private _config: GcxConfig | null = null;
+  private readonly _config = signal<GcxConfig | null>(null);
+  /** Currently loaded config, reactively. `null` until `load()` resolves. */
+  readonly config = this._config.asReadonly();
+
   private _pending: Promise<GcxConfig> | null = null;
+  private _loadedFor: string | null = null;
 
   toggleSidebar(): void {
     this.sidebarOpen.update((v) => !v);
@@ -36,22 +53,95 @@ export class GcxCoreService {
     this.sidebarOpen.set(false);
   }
 
-  async load(file: string = GCX_CORE_FILE): Promise<GcxConfig> {
-    if (this._config) return this._config;
-    if (!this._pending) {
-      this._pending = firstValueFrom(this.http.get<GcxConfig>(file)).then((cfg) => {
-        this._config = cfg ?? {};
-        return this._config;
-      });
-    }
+  /**
+   * Load a config. Pass a string for legacy local mode (defaults to
+   * `/assets/gcx.json`), or a `GcxRepoSource` to read
+   * `geocontext.json` from a public GitHub repo via jsdelivr. The repo
+   * context is remembered so asset URLs in the config can be rewritten.
+   */
+  async load(source?: GcxLoadSource): Promise<GcxConfig> {
+    const { configUrl, repo } = this.resolveLoadSource(source);
+
+    const cached = this._config();
+    if (this._loadedFor === configUrl && cached) return cached;
+
+    this._loadedFor = configUrl;
+    this.currentRepo.set(repo);
+    this._pending = firstValueFrom(this.http.get<GcxConfig>(configUrl)).then((cfg) => {
+      const rewritten = this.rewriteAssetPaths(cfg ?? {}, repo);
+      this._config.set(rewritten);
+      return rewritten;
+    });
     return this._pending;
   }
 
   getConf<T = any>(key: string): T | undefined {
-    return this._config?.[key] as T | undefined;
+    const cfg = this._config();
+    return cfg?.[key] as T | undefined;
   }
 
   snapshot(): GcxConfig | null {
-    return this._config;
+    return this._config();
+  }
+
+  /**
+   * Rewrites a config-supplied path/URL to something the browser can fetch.
+   *
+   * - Absolute http(s) URL → returned unchanged.
+   * - `/<user>/<project>/assets/<path>` → jsdelivr URL for that repo's asset.
+   *   Branch defaults to HEAD; consumers may include `@<branch>` after the
+   *   project, e.g. `/foo/bar@main/assets/x.csv`.
+   * - `/assets/<path>` while in repo mode → rewritten to the current repo's
+   *   `/<user>/<project>/assets/<path>` and then to jsdelivr.
+   * - Anything else → returned unchanged (caller resolves locally).
+   */
+  resolveAssetUrl(source: string): string {
+    if (!source) return source;
+    if (/^https?:\/\//i.test(source)) return source;
+
+    const repo = this.currentRepo();
+
+    const m = source.match(/^\/([^/]+)\/([^/@]+)(?:@([^/]+))?\/assets\/(.+)$/);
+    if (m) {
+      const [, user, project, branchFromPath, rest] = m;
+      const branch = branchFromPath || 'HEAD';
+      return `${GCX_JSDELIVR_BASE}/${user}/${project}@${branch}/${rest}`;
+    }
+
+    if (repo && source.startsWith('/assets/')) {
+      const branch = repo.branch ?? 'HEAD';
+      return `${GCX_JSDELIVR_BASE}/${repo.user}/${repo.project}@${branch}/${source.slice(1)}`;
+    }
+
+    return source;
+  }
+
+  private resolveLoadSource(source?: GcxLoadSource): {
+    configUrl: string;
+    repo: GcxRepoSource | null;
+  } {
+    if (!source) return { configUrl: GCX_CORE_FILE, repo: null };
+    if (typeof source === 'string') return { configUrl: source, repo: null };
+
+    const branch = source.branch ?? 'HEAD';
+    const path = source.path ?? 'geocontext.json';
+    const configUrl = `${GCX_JSDELIVR_BASE}/${source.user}/${source.project}@${branch}/${path}`;
+    return { configUrl, repo: { ...source, branch, path } };
+  }
+
+  private rewriteAssetPaths(cfg: GcxConfig, repo: GcxRepoSource | null): GcxConfig {
+    if (!cfg) return cfg;
+    const out = { ...cfg };
+    if (Array.isArray(cfg.datasources)) {
+      out.datasources = cfg.datasources.map((ds) => this.rewriteDatasource(ds));
+    }
+    return out;
+  }
+
+  private rewriteDatasource(ds: any): any {
+    if (!ds || typeof ds !== 'object') return ds;
+    const conf = ds.conf;
+    if (!conf || typeof conf !== 'object' || typeof conf.source !== 'string') return ds;
+    return { ...ds, conf: { ...conf, source: this.resolveAssetUrl(conf.source) } };
   }
 }

--- a/projects/gcx-core/src/lib/gcx-map/gcx-map.component.ts
+++ b/projects/gcx-core/src/lib/gcx-map/gcx-map.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, signal, viewChild } from '@angular/core';
+import { Component, effect, inject, signal, viewChild } from '@angular/core';
 import { JsonPipe } from '@angular/common';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatTabsModule } from '@angular/material/tabs';
@@ -151,7 +151,7 @@ interface ConfiguredDatasource {
     `,
   ],
 })
-export class GcxMapComponent implements OnInit {
+export class GcxMapComponent {
   readonly gcx = inject(GcxCoreService);
 
   readonly map = viewChild<MnMapComponent>('map');
@@ -167,16 +167,19 @@ export class GcxMapComponent implements OnInit {
   readonly selectedTab = signal<number>(0);
   readonly selectedItem = signal<any>(null);
 
-  async ngOnInit(): Promise<void> {
-    const conf = await this.gcx.load();
-    this.center.set(conf.center ?? [0, 0]);
-    this.startzoom.set(conf.startzoom ?? 1);
-    this.minzoom.set(conf.minzoom ?? 1);
-    this.maxzoom.set(conf.maxzoom ?? 19);
-    this.datasources.set(conf.datasources ?? []);
-    this.layers.set(
-      (conf.layers ?? []).map((l: any) => ({ ...l, visible: true }))
-    );
+  constructor() {
+    effect(() => {
+      const conf = this.gcx.config();
+      if (!conf) return;
+      this.center.set(conf.center ?? [0, 0]);
+      this.startzoom.set(conf.startzoom ?? 1);
+      this.minzoom.set(conf.minzoom ?? 1);
+      this.maxzoom.set(conf.maxzoom ?? 19);
+      this.datasources.set(conf.datasources ?? []);
+      this.layers.set(
+        (conf.layers ?? []).map((l: any) => ({ ...l, visible: true })),
+      );
+    });
   }
 
   toggleVisible(layer: ConfiguredLayer): void {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,7 +1,19 @@
 import { Routes } from '@angular/router';
 import { MapRouteComponent } from './map-route.component';
+import { RepoMapRouteComponent } from './repo-map-route.component';
 
 export const routes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'map' },
   { path: 'map', component: MapRouteComponent },
+
+  // Repo-driven views: <domain>/<user>/<project>/map renders the map from
+  // `geocontext.json` in that public GitHub repo (via jsdelivr).
+  // Optional query params: ?branch=<ref>&path=<file>
+  // `assets` is reserved at the top level — GitHub usernames can't take that
+  // value — so /assets/<…> never collides with the :user pattern.
+  { path: ':user/:project/map', component: RepoMapRouteComponent },
+
+  // /:user/:project/static/:target — pending chcx-static port.
+  // /:user/:project/assets/<path> — handled by GcxCoreService.resolveAssetUrl
+  // when references appear inside a loaded geocontext.json; no route needed.
 ];

--- a/src/app/map-route.component.ts
+++ b/src/app/map-route.component.ts
@@ -1,14 +1,13 @@
-import { Component } from '@angular/core';
-import { GcxMapComponent } from '@openhistorymap/gcx-core';
+import { Component, inject, OnInit } from '@angular/core';
+import { GcxCoreService, GcxMapComponent } from '@openhistorymap/gcx-core';
 import { MnGeoFlavoursMaplibreDirective } from '@openhistorymap/mn-geo-flavours-mapbox';
 
 /**
- * Thin wrapper that chooses the rendering flavour for `<gcx-map>`.
- * Default is MapLibre-GL. Swap `MnGeoFlavoursMaplibreDirective` for
- * `MnGeoFlavoursLeafletDirective` (from `@openhistorymap/mn-geo-flavours-leaflet`)
- * if a given deployment needs Leaflet — e.g. to keep GeoMQTT layers working
- * (GeoMQTT still emits Leaflet-native objects; descriptor support is a
- * follow-up).
+ * Default map route. Loads `/assets/gcx.json` (the local config), then
+ * renders `<gcx-map>` with the MapLibre flavour. Swap
+ * `MnGeoFlavoursMaplibreDirective` for the Leaflet one if a deployment
+ * needs `geomqtt` live-stream layers (those still emit Leaflet-native
+ * objects until descriptor support lands).
  */
 @Component({
   selector: 'app-map-route',
@@ -21,4 +20,10 @@ import { MnGeoFlavoursMaplibreDirective } from '@openhistorymap/mn-geo-flavours-
   `,
   styles: [':host { display: block; width: 100%; height: 100%; }'],
 })
-export class MapRouteComponent {}
+export class MapRouteComponent implements OnInit {
+  private readonly gcx = inject(GcxCoreService);
+
+  ngOnInit(): void {
+    void this.gcx.load();
+  }
+}

--- a/src/app/repo-map-route.component.ts
+++ b/src/app/repo-map-route.component.ts
@@ -1,0 +1,86 @@
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { combineLatest } from 'rxjs';
+import { GcxCoreService, GcxMapComponent } from '@openhistorymap/gcx-core';
+import { MnGeoFlavoursMaplibreDirective } from '@openhistorymap/mn-geo-flavours-mapbox';
+
+/**
+ * Route at `/:user/:project/map`. Loads `geocontext.json` (or the `path=`
+ * query) from the GitHub repo at `:user/:project` via jsdelivr and renders
+ * the standard `<gcx-map>`. Query params:
+ *   - `branch=<ref>` — git ref (default `HEAD`)
+ *   - `path=<file>`  — config file path within repo (default `geocontext.json`)
+ */
+@Component({
+  selector: 'app-repo-map-route',
+  standalone: true,
+  imports: [GcxMapComponent, MnGeoFlavoursMaplibreDirective],
+  template: `
+    @if (status() === 'ready') {
+      <gcx-map>
+        <div mnMapFlavourMaplibre></div>
+      </gcx-map>
+    } @else if (status() === 'error') {
+      <div class="repo-msg repo-error">
+        <strong>Could not load {{ user() }}/{{ project() }}</strong>
+        <p>{{ message() }}</p>
+        <small>Tried: <code>{{ tried() }}</code></small>
+      </div>
+    } @else {
+      <div class="repo-msg">Loading {{ user() }}/{{ project() }}…</div>
+    }
+  `,
+  styles: [
+    `
+      :host { display: block; width: 100%; height: 100%; }
+      .repo-msg {
+        padding: 24px;
+        font-family: sans-serif;
+        max-width: 640px;
+        margin: 0 auto;
+      }
+      .repo-error { color: #b00020; }
+      .repo-msg code { word-break: break-all; }
+    `,
+  ],
+})
+export class RepoMapRouteComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly gcx = inject(GcxCoreService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly user = signal('');
+  readonly project = signal('');
+  readonly status = signal<'loading' | 'ready' | 'error'>('loading');
+  readonly message = signal<string>('');
+  readonly tried = signal<string>('');
+
+  constructor() {
+    combineLatest([this.route.paramMap, this.route.queryParamMap])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(([params, query]) => {
+        const user = params.get('user') ?? '';
+        const project = params.get('project') ?? '';
+        const branch = query.get('branch') ?? undefined;
+        const path = query.get('path') ?? undefined;
+
+        this.user.set(user);
+        this.project.set(project);
+        this.status.set('loading');
+
+        this.gcx
+          .load({ user, project, branch, path })
+          .then(() => this.status.set('ready'))
+          .catch((err: any) => {
+            this.message.set(err?.message ?? String(err));
+            const ref = branch ?? 'HEAD';
+            const file = path ?? 'geocontext.json';
+            this.tried.set(
+              `https://cdn.jsdelivr.net/gh/${user}/${project}@${ref}/${file}`,
+            );
+            this.status.set('error');
+          });
+      });
+  }
+}


### PR DESCRIPTION
Adds a public-by-default visualization route. Browsing `<domain>/<user>/<project>/map` loads `geocontext.json` from that repo via jsdelivr and renders the standard `<gcx-map>` — no backend, no fork, no build on the data side. Optional `?branch=<ref>` and `?path=<file>` query params for non-default branches and alternative config locations.

- GcxCoreService.load() now accepts a `GcxRepoSource` ({user, project, branch?, path?}) alongside the legacy URL string. Constructs the jsdelivr URL and remembers the repo as `currentRepo` (signal).
- GcxCoreService.resolveAssetUrl rewrites datasource source paths:
  - https://… pass through
  - /<u>/<p>[@<branch>]/assets/<…>  -> jsdelivr <u>/<p>@<branch>/<…>
  - /assets/<…> in repo mode        -> jsdelivr current-repo's <…>
  - everything else returned unchanged
  Datasource sources in the loaded config are rewritten on load.
- GcxMapComponent is now reactive: the load() side-effect moved out of
  ngOnInit; an effect() reads gcx.config() (a new readonly signal) so
  re-navigating between routes that load different sources just works.
- MapRouteComponent now explicitly calls gcx.load() on mount (paired
  with the reactivity refactor above).
- RepoMapRouteComponent is the new route handler with loading/error
  states; reads :user/:project from the route and branch/path from
  query params.
- `assets` reserved at the workspace root (it's not a valid GitHub
  username) so /assets/<…> and /<user>/<project>/map can't collide.

Pending: /:user/:project/static/<target> awaits the chcx-static port.