### PR TITLE
ci: deploy the app to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,63 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [master, rewrite/angular-latest]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Pages allows one in-flight deploy at a time; cancel older runs in the
+# same group so the latest push wins without piling up queued jobs.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install
+        run: npm ci --no-audit --no-fund
+
+      - name: Build ported libraries + app
+        env:
+          # Pages serves at https://www.openhistorymap.org/geocontext-front/,
+          # so all asset/router URLs need the project-page prefix.
+          BASE_HREF: /geocontext-front/
+        run: ./scripts/build-ported.sh
+
+      - name: Add SPA 404 fallback
+        # Path-based routes (`/:user/:project/map`, etc.) deep-link to URLs
+        # GitHub Pages can't statically serve. Copying index.html to 404.html
+        # lets Pages return the SPA shell for any unknown path; Angular's
+        # router then resolves the route client-side.
+        run: cp dist/geocontext-front/browser/index.html dist/geocontext-front/browser/404.html
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/geocontext-front/browser
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/scripts/build-ported.sh
+++ b/scripts/build-ported.sh
@@ -26,5 +26,9 @@ for lib in "${LIBS[@]}"; do
 done
 
 echo "::group::ng build (app)"
-npx ng build --configuration=production
+APP_FLAGS=()
+if [ -n "${BASE_HREF:-}" ]; then
+  APP_FLAGS+=(--base-href "$BASE_HREF")
+fi
+npx ng build --configuration=production "${APP_FLAGS[@]}"
 echo "::endgroup::"


### PR DESCRIPTION
Repo's Pages is already wired to `build_type: workflow` (custom domain www.openhistorymap.org, project served under /geocontext-front/), so this just adds the workflow that produces and uploads the artifact.

- .github/workflows/pages.yml: build + deploy job pair, triggers on master, rewrite/angular-latest, and workflow_dispatch. Copies index.html → 404.html in the artifact so path-based deep-links (e.g. /:user/:project/map) survive Pages' static serving — Pages returns the SPA shell for unknown paths and Angular's router takes over client-side.
- scripts/build-ported.sh: honors a BASE_HREF env var, passing it to the final `ng build` so all router/asset URLs get prefixed. The Pages workflow sets BASE_HREF=/geocontext-front/ to match the project-page path.

Concurrency group `pages` cancels superseded runs so the latest push always lands. Pages permissions: contents:read, pages:write, id-token:write (the standard Pages-deploy triple).