### PR TITLE
feat(gcx): probe gcx.json as a fallback for geocontext.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,11 @@ by GeoContext directly — no fork, no build:
 ```
 
 The route loads the config from
-`https://cdn.jsdelivr.net/gh/<user>/<project>@<branch>/<path>` (defaults
-`HEAD` and `geocontext.json`). Datasource references inside the config are
-rewritten by `GcxCoreService.resolveAssetUrl`:
+`https://cdn.jsdelivr.net/gh/<user>/<project>@<branch>/<path>`. The branch
+defaults to `HEAD`. When `path` is omitted, the loader probes
+`geocontext.json` first and falls back to `gcx.json` (the legacy filename)
+on a 404 — non-404 errors surface immediately. Datasource references inside
+the config are rewritten by `GcxCoreService.resolveAssetUrl`:
 
 - Absolute URLs pass through.
 - `/<user>/<project>/assets/<file>` (with optional `@<branch>` after project)

--- a/projects/gcx-core/src/lib/gcx-core.service.ts
+++ b/projects/gcx-core/src/lib/gcx-core.service.ts
@@ -5,6 +5,11 @@ import { firstValueFrom } from 'rxjs';
 export const GCX_CORE_FILE = '/assets/gcx.json';
 export const GCX_JSDELIVR_BASE = 'https://cdn.jsdelivr.net/gh';
 
+/** Filenames probed at a repo root when the caller didn't pass an explicit
+ *  `path`. `geocontext.json` is preferred; `gcx.json` is the legacy name and
+ *  kept for backwards compatibility with older repos. */
+export const GCX_REPO_CANDIDATE_PATHS = ['geocontext.json', 'gcx.json'] as const;
+
 export interface GcxConfig {
   title?: string;
   type?: string;
@@ -60,14 +65,15 @@ export class GcxCoreService {
    * context is remembered so asset URLs in the config can be rewritten.
    */
   async load(source?: GcxLoadSource): Promise<GcxConfig> {
-    const { configUrl, repo } = this.resolveLoadSource(source);
+    const { candidates, repo } = this.resolveLoadSource(source);
+    const cacheKey = candidates[0];
 
     const cached = this._config();
-    if (this._loadedFor === configUrl && cached) return cached;
+    if (this._loadedFor === cacheKey && cached) return cached;
 
-    this._loadedFor = configUrl;
+    this._loadedFor = cacheKey;
     this.currentRepo.set(repo);
-    this._pending = firstValueFrom(this.http.get<GcxConfig>(configUrl)).then((cfg) => {
+    this._pending = this.fetchFirstAvailable(candidates).then((cfg) => {
       const rewritten = this.rewriteAssetPaths(cfg ?? {}, repo);
       this._config.set(rewritten);
       return rewritten;
@@ -117,16 +123,36 @@ export class GcxCoreService {
   }
 
   private resolveLoadSource(source?: GcxLoadSource): {
-    configUrl: string;
+    candidates: string[];
     repo: GcxRepoSource | null;
   } {
-    if (!source) return { configUrl: GCX_CORE_FILE, repo: null };
-    if (typeof source === 'string') return { configUrl: source, repo: null };
+    if (!source) return { candidates: [GCX_CORE_FILE], repo: null };
+    if (typeof source === 'string') return { candidates: [source], repo: null };
 
     const branch = source.branch ?? 'HEAD';
-    const path = source.path ?? 'geocontext.json';
-    const configUrl = `${GCX_JSDELIVR_BASE}/${source.user}/${source.project}@${branch}/${path}`;
-    return { configUrl, repo: { ...source, branch, path } };
+    const base = `${GCX_JSDELIVR_BASE}/${source.user}/${source.project}@${branch}`;
+    const paths = source.path ? [source.path] : [...GCX_REPO_CANDIDATE_PATHS];
+    return {
+      candidates: paths.map((p) => `${base}/${p}`),
+      repo: { ...source, branch, path: source.path },
+    };
+  }
+
+  private async fetchFirstAvailable(urls: string[]): Promise<GcxConfig> {
+    let lastError: any;
+    for (const url of urls) {
+      try {
+        return await firstValueFrom(this.http.get<GcxConfig>(url));
+      } catch (e: any) {
+        // Only fall through on 404; surface real network/CORS/server errors.
+        if (e?.status === 404) {
+          lastError = e;
+          continue;
+        }
+        throw e;
+      }
+    }
+    throw lastError ?? new Error(`No config found at: ${urls.join(', ')}`);
   }
 
   private rewriteAssetPaths(cfg: GcxConfig, repo: GcxRepoSource | null): GcxConfig {

--- a/src/app/repo-map-route.component.ts
+++ b/src/app/repo-map-route.component.ts
@@ -2,7 +2,12 @@ import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { combineLatest } from 'rxjs';
-import { GcxCoreService, GcxMapComponent } from '@openhistorymap/gcx-core';
+import {
+  GcxCoreService,
+  GcxMapComponent,
+  GCX_JSDELIVR_BASE,
+  GCX_REPO_CANDIDATE_PATHS,
+} from '@openhistorymap/gcx-core';
 import { MnGeoFlavoursMaplibreDirective } from '@openhistorymap/mn-geo-flavours-mapbox';
 
 /**
@@ -25,7 +30,8 @@ import { MnGeoFlavoursMaplibreDirective } from '@openhistorymap/mn-geo-flavours-
       <div class="repo-msg repo-error">
         <strong>Could not load {{ user() }}/{{ project() }}</strong>
         <p>{{ message() }}</p>
-        <small>Tried: <code>{{ tried() }}</code></small>
+        <small>Tried:</small>
+        <pre>{{ tried() }}</pre>
       </div>
     } @else {
       <div class="repo-msg">Loading {{ user() }}/{{ project() }}…</div>
@@ -41,7 +47,14 @@ import { MnGeoFlavoursMaplibreDirective } from '@openhistorymap/mn-geo-flavours-
         margin: 0 auto;
       }
       .repo-error { color: #b00020; }
-      .repo-msg code { word-break: break-all; }
+      .repo-msg pre {
+        background: #f5f5f5;
+        padding: 8px;
+        border-radius: 4px;
+        white-space: pre-wrap;
+        word-break: break-all;
+        font-size: 0.85em;
+      }
     `,
   ],
 })
@@ -75,10 +88,9 @@ export class RepoMapRouteComponent {
           .catch((err: any) => {
             this.message.set(err?.message ?? String(err));
             const ref = branch ?? 'HEAD';
-            const file = path ?? 'geocontext.json';
-            this.tried.set(
-              `https://cdn.jsdelivr.net/gh/${user}/${project}@${ref}/${file}`,
-            );
+            const base = `${GCX_JSDELIVR_BASE}/${user}/${project}@${ref}`;
+            const paths = path ? [path] : [...GCX_REPO_CANDIDATE_PATHS];
+            this.tried.set(paths.map((p) => `${base}/${p}`).join('\n'));
             this.status.set('error');
           });
       });


### PR DESCRIPTION
When loading from a public repo without an explicit `path` query param, the loader now tries `geocontext.json` first and falls back to `gcx.json` (the legacy filename used by older GeoContext setups) on a
404. Non-404 errors surface immediately so real network/CORS/server failures aren't masked.

- GcxCoreService: GCX_REPO_CANDIDATE_PATHS exported; resolveLoadSource returns a candidate URL list; new fetchFirstAvailable walks them and bails on non-404. Cache key remains the first candidate so re-loads hit the cache regardless of which file actually answered.
- RepoMapRouteComponent error display now lists every URL it tried so it's obvious which filenames were probed.
- Local mode (`/assets/gcx.json`) unchanged — single candidate.