### PR TITLE
feat(gcx): background + dem fields in geocontext.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Save this to `geocontext.json` at the **root** of any public GitHub repo:
   "title": "My map",
   "center": [44.292, 13.975],
   "startzoom": 5, "minzoom": 1, "maxzoom": 18,
+  "background": "osm",
   "datasources": [
     { "name": "places", "type": "geojson+http+remote",
       "conf": { "source": "data/places.geojson" } }
@@ -64,6 +65,8 @@ The legacy filename `gcx.json` is also accepted as a fallback.
 | `title` | string | Page + masthead title. |
 | `center` | `[lat, lon]` *or* `{ lat, lon }` | Initial map centre. Latitude first (everyday "44°N 13°E" order). |
 | `startzoom` / `minzoom` / `maxzoom` | number | Initial zoom + interaction limits. |
+| `background` | string \| object | Basemap layer — see *Background basemap* below. Optional. |
+| `dem` | string \| object | Digital Elevation Model source — see *Terrain & hillshade* below. Optional. |
 | `datasources` | array | Named data sources fetched at load — see *datasource types* below. |
 | `layers` | array | Layers stacked on the map (top of array = top of stack) — see *layer types* below. |
 
@@ -71,14 +74,97 @@ The legacy filename `gcx.json` is also accepted as a fallback.
 
 | `type` | What it draws |
 |---|---|
+| `raster-tiled` | Generic XYZ raster tile layer. `conf.url` is the template (`{z}/{x}/{y}` or `{s}` for subdomains). Use this when no dedicated provider library exists. |
+| `raster-dem` | Elevation raster (terrarium / mapbox-rgb). Renders hillshade and (optionally) 3D terrain on the MapLibre flavour; ignored on Leaflet. |
 | `osm-tiled` | OpenStreetMap raster tiles. No `datasource` needed. |
 | `ofm-tiled` | OpenFantasyMaps render server. |
 | `carto-voyager` · `carto-light` · `carto-dark` · `carto-positron` (and matching `*-nolabels`) | CARTO basemap variants. |
 | `features` | Renders a datasource's GeoJSON as styled markers / lines / polygons. Pair with a `style.options` block (`radius`, `fillColor`, `color`, `weight`, `opacity`, `fillOpacity`). |
 | `geomqtt` | Subscribes to an MQTT broker and pushes incoming GeoJSON features onto the map live. `conf` requires `broker` (ws/wss URL) and `topic`; optional `idField`, `maxFeatures`. (Currently Leaflet-only — see *known gaps*.) |
 
-If `geocontext.json` declares only feature layers, GeoContext shows a
-default OSM raster behind them so the canvas isn't empty.
+If `geocontext.json` declares no `background` (and no tile layer in
+`layers[]`), the MapLibre flavour falls back to its default OpenFreeMap
+"bright" style so the canvas isn't empty. The Leaflet flavour does not —
+declare a `background` (or any tile layer) when targeting Leaflet.
+
+### Background basemap
+
+`background` is a shorthand for declaring a single basemap layer
+without spelling out a `layers[]` entry. Accepted forms:
+
+```json
+{ "background": "osm" }                                            // built-in alias
+{ "background": "ofm" }                                            // OpenFantasyMaps
+{ "background": "carto-voyager" }                                  // any registered tile-layer type
+{ "background": "https://tile.example.org/{z}/{x}/{y}.png" }       // raw URL
+{ "background": {
+    "url": "https://{s}.tile.example.org/{z}/{x}/{y}.png",
+    "subdomains": "abc",
+    "attribution": "© Example",
+    "maxZoom": 19
+  } }
+{ "background": { "type": "osm-tiled", "conf": { "url": "https://my-mirror/{z}/{x}/{y}.png" } } }
+{ "background": "none" }                                           // suppress any default
+```
+
+The resolved background sits at the **bottom** of the visual stack
+(below `layers[]` and `dem`) and shows up at the bottom of the sidebar
+list, where the user can toggle it off like any other layer.
+
+### Terrain & hillshade
+
+`dem` registers a Digital Elevation Model raster source. The MapLibre
+flavour turns it into a hillshade GL layer and (optionally) 3D terrain;
+the Leaflet flavour ignores it with a warning.
+
+```json
+{
+  "dem": {
+    "url": "https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png",
+    "encoding": "terrarium",
+    "hillshade": true,
+    "terrain": true,
+    "exaggeration": 1.4,
+    "attribution": "© Mapzen / AWS Terrain Tiles"
+  }
+}
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `url` | — | Tile template. `{z}/{x}/{y}` (and `{s}` with `subdomains`) supported. |
+| `encoding` | `"terrarium"` | Pixel encoding scheme. `"terrarium"` (Mapzen / AWS) or `"mapbox"` (terrain-rgb). |
+| `hillshade` | `true` | Render a hillshade GL layer. Set `false` to register the source for terrain only. |
+| `terrain` | `false` | Enable 3D terrain (`map.setTerrain`). MapLibre only. |
+| `exaggeration` | `1` | Vertical exaggeration when `terrain: true`. |
+| `minZoom` / `maxZoom` | — | Zoom bounds for the source. |
+
+A bare URL string is shorthand for `{ url, encoding: "terrarium",
+hillshade: true }`:
+
+```json
+{ "dem": "https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png" }
+```
+
+#### Worked example: Mediterranean relief over OSM
+
+```json
+{
+  "title": "Adriatic terrain",
+  "center": [43.5, 14.5],
+  "startzoom": 6,
+  "background": "carto-positron",
+  "dem": {
+    "url": "https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png",
+    "encoding": "terrarium",
+    "hillshade": true,
+    "terrain": true,
+    "exaggeration": 1.2
+  },
+  "datasources": [],
+  "layers": []
+}
+```
 
 ### Built-in datasource types
 

--- a/projects/gcx-core/src/lib/gcx-core.service.ts
+++ b/projects/gcx-core/src/lib/gcx-core.service.ts
@@ -20,6 +20,37 @@ export interface GcxConfig {
   search?: boolean;
   datasources?: any[];
   layers?: any[];
+  /**
+   * Optional basemap shorthand. Accepts a registered layer-type alias
+   * (`'osm'`, `'ofm'`, `'carto-voyager'`, …), a raw tile URL template, or a
+   * full `{ type, conf }` layer descriptor object. `'none'` / `false`
+   * suppress any background layer.
+   */
+  background?: string | false | null | {
+    type?: string;
+    name?: string;
+    url?: string;
+    conf?: any;
+    style?: any;
+    [k: string]: any;
+  };
+  /**
+   * Optional Digital Elevation Model source. Object form takes a tile URL
+   * and an optional `encoding` (`'terrarium'` | `'mapbox'`), plus
+   * `hillshade` / `terrain` / `exaggeration` flags consumed by the MapLibre
+   * flavour. A bare URL string is shorthand for `{ url, encoding: 'terrarium' }`.
+   */
+  dem?: string | false | null | {
+    type?: string;
+    name?: string;
+    url?: string;
+    encoding?: 'terrarium' | 'mapbox';
+    hillshade?: boolean;
+    terrain?: boolean;
+    exaggeration?: number;
+    conf?: any;
+    [k: string]: any;
+  };
   [k: string]: any;
 }
 

--- a/projects/gcx-core/src/lib/gcx-map/gcx-map.component.ts
+++ b/projects/gcx-core/src/lib/gcx-map/gcx-map.component.ts
@@ -38,6 +38,7 @@ interface ConfiguredLayer {
   type: string;
   datasource?: string;
   style?: any;
+  conf?: any;
   visible: boolean;
 }
 
@@ -45,6 +46,64 @@ interface ConfiguredDatasource {
   name: string;
   type: string;
   conf: any;
+}
+
+/**
+ * Shorthand strings the user can put in `gcx.json#background` that map to a
+ * registered layer type. Anything not in this map (and not a URL) is passed
+ * through as a layer type name, so users can plug in any registered tile
+ * provider without enumerating it here.
+ */
+const BACKGROUND_ALIASES: Record<string, string> = {
+  osm: 'osm-tiled',
+  ofm: 'ofm-tiled',
+};
+
+function resolveBackgroundLayer(bg: any): ConfiguredLayer | null {
+  if (bg == null || bg === false || bg === 'none') return null;
+  if (typeof bg === 'string') {
+    if (/^https?:\/\//i.test(bg)) {
+      return { name: 'background', type: 'raster-tiled', conf: { url: bg }, visible: true };
+    }
+    const type = BACKGROUND_ALIASES[bg] ?? bg;
+    return { name: 'background', type, conf: {}, visible: true };
+  }
+  if (typeof bg === 'object') {
+    if (bg.type) {
+      return {
+        name: bg.name ?? 'background',
+        type: bg.type,
+        conf: bg.conf ?? {},
+        style: bg.style,
+        visible: true,
+      };
+    }
+    if (bg.url) {
+      return { name: bg.name ?? 'background', type: 'raster-tiled', conf: bg, visible: true };
+    }
+  }
+  return null;
+}
+
+function resolveDemLayer(dem: any): ConfiguredLayer | null {
+  if (dem == null || dem === false) return null;
+  if (typeof dem === 'string') {
+    return { name: 'dem', type: 'raster-dem', conf: { url: dem }, visible: true };
+  }
+  if (typeof dem === 'object') {
+    if (dem.type) {
+      return {
+        name: dem.name ?? 'dem',
+        type: dem.type,
+        conf: dem.conf ?? {},
+        visible: true,
+      };
+    }
+    if (dem.url) {
+      return { name: dem.name ?? 'dem', type: 'raster-dem', conf: dem, visible: true };
+    }
+  }
+  return null;
 }
 
 /**
@@ -194,6 +253,7 @@ interface ConfiguredDatasource {
               [name]="layer.name"
               [type]="layer.type"
               [datasource]="layer.datasource"
+              [conf]="layer.conf ?? {}"
               (layerClicked)="onFeature($event)"
             >
               @if (layer.style) {
@@ -545,9 +605,21 @@ export class GcxMapComponent {
       this.minzoom.set(conf.minzoom ?? 1);
       this.maxzoom.set(conf.maxzoom ?? 19);
       this.datasources.set(conf.datasources ?? []);
-      this.layers.set(
-        (conf.layers ?? []).map((l: any) => ({ ...l, visible: true })),
-      );
+      // Sidebar order: ids[0] is drawn on top. So user layers come first,
+      // then DEM (hillshade above the basemap), then background last so it
+      // ends up at the bottom of the visual stack.
+      const userLayers: ConfiguredLayer[] = (conf.layers ?? []).map((l: any) => ({
+        ...l,
+        visible: true,
+      }));
+      const dem = resolveDemLayer(conf['dem']);
+      const background = resolveBackgroundLayer(conf['background']);
+      const combined: ConfiguredLayer[] = [
+        ...userLayers,
+        ...(dem ? [dem] : []),
+        ...(background ? [background] : []),
+      ];
+      this.layers.set(combined);
     });
   }
 

--- a/projects/mn-geo-flavours-leaflet/src/lib/mn-geo-flavours-leaflet.directive.ts
+++ b/projects/mn-geo-flavours-leaflet/src/lib/mn-geo-flavours-leaflet.directive.ts
@@ -254,6 +254,10 @@ export class MnGeoFlavoursLeafletDirective extends MnMapFlavourDirective impleme
         console.warn('mn-geo-flavours-leaflet: vector-tiles descriptor not supported; use maplibre flavour.');
         return null;
       }
+      case 'raster-dem': {
+        console.warn('mn-geo-flavours-leaflet: raster-dem descriptor not supported; use maplibre flavour for DEM / hillshade.');
+        return null;
+      }
     }
   }
 }

--- a/projects/mn-geo-flavours-mapbox/src/lib/mn-geo-flavours-maplibre.directive.ts
+++ b/projects/mn-geo-flavours-mapbox/src/lib/mn-geo-flavours-maplibre.directive.ts
@@ -48,6 +48,10 @@ export class MnGeoFlavoursMaplibreDirective extends MnMapFlavourDirective implem
   private readonly ownedSourceIds = new Set<string>();
   private readonly ownedLayerIds = new Set<string>();
   private readonly subscriptions = new Map<string, () => void>();
+  /** DEM source id currently bound to the map's terrain (via setTerrain).
+   *  Tracked so removeLayer can unset terrain before tearing the source
+   *  down — leaving terrain bound to a removed source crashes MapLibre. */
+  private terrainSourceId: string | undefined;
   /** Pin-mode layers: each id owns an array of HTML-overlay markers that
    *  setLayerVisibility / removeLayer manage separately from GL layers. */
   private readonly markersByLayerId = new Map<string, MaplibreMarker[]>();
@@ -135,6 +139,10 @@ export class MnGeoFlavoursMaplibreDirective extends MnMapFlavourDirective implem
       }
     }
     if (this.ownedSourceIds.has(id) && this._map.getSource(id)) {
+      if (this.terrainSourceId === id) {
+        try { this._map.setTerrain(null); } catch { /* ignore */ }
+        this.terrainSourceId = undefined;
+      }
       this._map.removeSource(id);
       this.ownedSourceIds.delete(id);
     }
@@ -318,6 +326,47 @@ export class MnGeoFlavoursMaplibreDirective extends MnMapFlavourDirective implem
           if (!map.getLayer(layerId)) {
             map.addLayer({ ...styleLayer, id: layerId, source: id });
             this.ownedLayerIds.add(layerId);
+          }
+        }
+        return;
+      }
+
+      case 'raster-dem': {
+        // DEM is two halves: a raster-dem source (always added so terrain /
+        // hillshade can attach to it) and an optional hillshade GL layer.
+        // setLayerOrder/Visibility key off `desc.id`, which is the hillshade
+        // layer when present — so toggling the sidebar row hides the visible
+        // shading without disturbing the underlying source.
+        const sourceId = desc.id;
+        if (!map.getSource(sourceId)) {
+          map.addSource(sourceId, {
+            type: 'raster-dem',
+            tiles: desc.urls,
+            tileSize: desc.tileSize ?? 256,
+            encoding: desc.encoding ?? 'terrarium',
+            minzoom: desc.minZoom,
+            maxzoom: desc.maxZoom,
+            attribution: desc.attribution,
+          });
+          this.ownedSourceIds.add(sourceId);
+        }
+        if (desc.hillshade !== false && !map.getLayer(sourceId)) {
+          map.addLayer({
+            id: sourceId,
+            type: 'hillshade',
+            source: sourceId,
+            paint: {
+              'hillshade-shadow-color': '#473b24',
+            },
+          });
+          this.ownedLayerIds.add(sourceId);
+        }
+        if (desc.terrain) {
+          try {
+            map.setTerrain({ source: sourceId, exaggeration: desc.exaggeration ?? 1 });
+            this.terrainSourceId = sourceId;
+          } catch (e) {
+            console.warn('mn-geo-flavours-mapbox: setTerrain failed', e);
           }
         }
         return;

--- a/projects/mn-geo-layers/src/lib/descriptors.ts
+++ b/projects/mn-geo-layers/src/lib/descriptors.ts
@@ -28,6 +28,32 @@ export interface VectorTilesDescriptor {
   attribution?: string;
 }
 
+/**
+ * Digital Elevation Model raster tiles. Tile pixels encode elevation values
+ * (terrarium or mapbox-rgb), used by the renderer for hillshading and
+ * optional 3D terrain. Flavours that don't speak DEM (Leaflet today) ignore
+ * this descriptor with a warning.
+ */
+export interface RasterDemDescriptor {
+  kind: 'raster-dem';
+  id: string;
+  urls: string[];
+  /** Pixel encoding. `terrarium` (default) is the AWS / Mapzen scheme;
+   *  `mapbox` is the Mapbox terrain-rgb scheme. */
+  encoding?: 'terrarium' | 'mapbox';
+  tileSize?: number;
+  minZoom?: number;
+  maxZoom?: number;
+  attribution?: string;
+  /** Render a hillshade GL layer from the source. Default: true. Set to
+   *  false to register the DEM source for terrain only. */
+  hillshade?: boolean;
+  /** Enable 3D terrain (MapLibre `setTerrain`). Default: false. */
+  terrain?: boolean;
+  /** Vertical exaggeration when `terrain: true`. Default: 1. */
+  exaggeration?: number;
+}
+
 export interface GeoJsonFeaturesDescriptor {
   kind: 'geojson-features';
   id: string;
@@ -65,6 +91,7 @@ export interface GeoJsonFeaturesDescriptor {
 export type LayerDescriptor =
   | RasterTilesDescriptor
   | VectorTilesDescriptor
+  | RasterDemDescriptor
   | GeoJsonFeaturesDescriptor;
 
 export function isLayerDescriptor(value: unknown): value is LayerDescriptor {

--- a/projects/mn-geo-layers/src/lib/tiles.layer.ts
+++ b/projects/mn-geo-layers/src/lib/tiles.layer.ts
@@ -1,0 +1,84 @@
+import { EnvironmentProviders, inject, provideAppInitializer } from '@angular/core';
+import { Layer } from './layer.interface';
+import { RasterDemDescriptor, RasterTilesDescriptor } from './descriptors';
+import { MnGeoLayersRegistryService } from './mn-geo-layers-registry.service';
+
+function expandSubdomains(template: string, subdomains?: string): string[] {
+  if (!subdomains || !template.includes('{s}')) return [template];
+  return [...subdomains].map((s) => template.replace('{s}', s));
+}
+
+/**
+ * Generic XYZ raster tile layer driven entirely by configuration. Used for
+ * the top-level `background` field in `gcx.json` when the user supplies a
+ * raw URL, and available as a layer type (`raster-tiled`) for arbitrary tile
+ * services that don't warrant a dedicated provider library.
+ */
+export class RasterTiles extends Layer {
+  constructor() {
+    super();
+    this.setRequiresDatasources(false);
+  }
+
+  override create(): RasterTilesDescriptor {
+    const conf = this.getConfiguration() ?? {};
+    const url: string = conf.url;
+    const subdomains: string | undefined = conf.subdomains;
+    return {
+      kind: 'raster-tiles',
+      id: this.getName() || 'raster',
+      urls: expandSubdomains(url, subdomains),
+      tileSize: conf.tileSize ?? 256,
+      minZoom: conf.minZoom,
+      maxZoom: conf.maxZoom,
+      attribution: conf.attribution,
+      subdomains,
+    };
+  }
+}
+
+/**
+ * Digital Elevation Model tile layer. Emits a `raster-dem` descriptor that
+ * MapLibre turns into a `raster-dem` source plus an optional hillshade and
+ * 3D terrain. Fed from `gcx.json`'s top-level `dem` key by `<gcx-map>`, or
+ * used directly as a layer type (`raster-dem`).
+ */
+export class DemTiles extends Layer {
+  constructor() {
+    super();
+    this.setRequiresDatasources(false);
+  }
+
+  override create(): RasterDemDescriptor {
+    const conf = this.getConfiguration() ?? {};
+    const url: string = conf.url;
+    const subdomains: string | undefined = conf.subdomains;
+    return {
+      kind: 'raster-dem',
+      id: this.getName() || 'dem',
+      urls: expandSubdomains(url, subdomains),
+      encoding: conf.encoding ?? 'terrarium',
+      tileSize: conf.tileSize ?? 256,
+      minZoom: conf.minZoom,
+      maxZoom: conf.maxZoom,
+      attribution: conf.attribution,
+      hillshade: conf.hillshade ?? true,
+      terrain: conf.terrain ?? false,
+      exaggeration: conf.exaggeration ?? 1,
+    };
+  }
+}
+
+/**
+ * Registers the renderer-agnostic base tile layer types — `raster-tiled` for
+ * arbitrary XYZ raster tiles, `raster-dem` for elevation tiles. These power
+ * the top-level `background` and `dem` fields in `gcx.json` and let users
+ * declare any tile service without pulling in a provider library.
+ */
+export function provideMnGeoLayersBase(): EnvironmentProviders {
+  return provideAppInitializer(() => {
+    const reg = inject(MnGeoLayersRegistryService);
+    reg.register('raster-tiled', RasterTiles);
+    reg.register('raster-dem', DemTiles);
+  });
+}

--- a/projects/mn-geo-layers/src/public-api.ts
+++ b/projects/mn-geo-layers/src/public-api.ts
@@ -5,3 +5,4 @@ export * from './lib/mn-geo-layers-registry.service';
 export * from './lib/layersmanager.service';
 export * from './lib/feature.layer';
 export * from './lib/markers.layer';
+export * from './lib/tiles.layer';

--- a/public/assets/gcx.json
+++ b/public/assets/gcx.json
@@ -6,11 +6,7 @@
   "startzoom": 5,
   "maxzoom": 19,
   "search": true,
+  "background": "osm",
   "datasources": [],
-  "layers": [
-    {
-      "name": "OpenStreetMap",
-      "type": "osm-tiled"
-    }
-  ]
+  "layers": []
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,6 +3,7 @@ import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
+  provideMnGeoLayersBase,
   provideMnGeoLayersFeature,
   provideMnGeoLayersMarkers,
 } from '@openhistorymap/mn-geo-layers';
@@ -21,6 +22,9 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideHttpClient(),
     provideAnimationsAsync(),
+    // Generic raster-tiled / raster-dem layer types — power gcx.json's
+    // top-level `background` and `dem` fields.
+    provideMnGeoLayersBase(),
     // Default GeoJSON renderer (circles), pin-marker mode, + datasources.
     provideMnGeoLayersFeature(),
     provideMnGeoLayersMarkers(),


### PR DESCRIPTION
## Summary

- New top-level `background` field in `geocontext.json` — basemap shorthand accepting an alias (`"osm"`, `"ofm"`, `"carto-voyager"`, …), a raw tile URL template, or a full `{type, conf}` layer descriptor (also accepts `"none"` to suppress any default).
- New top-level `dem` field — Digital Elevation Model source. The MapLibre flavour renders it as a hillshade GL layer and (optionally) 3D terrain via `setTerrain`; the Leaflet flavour ignores it with a warning.
- Generic `raster-tiled` and `raster-dem` layer types in `mn-geo-layers`, registered via a new `provideMnGeoLayersBase()`. These power the two new fields and are also usable directly inside `layers[]` for any tile service that doesn't warrant a dedicated provider library.
- `RasterDemDescriptor` joins the renderer-agnostic descriptor union.
- README documents both fields with worked examples (Mediterranean relief over CARTO Positron with terrarium DEM).

## Test plan

- [x] `ng build mn-geo-layers && ng build mn-geo-flavours-{leaflet,mapbox} && ng build gcx-core` — all green.
- [x] `ng build` (app) — green; bundle stable (initial 2.21 MB / 513 kB transfer).
- [ ] Smoke: load `/map` with the updated `public/assets/gcx.json` (`"background": "osm"`) and confirm OSM tiles render.
- [ ] Smoke: switch `background` to `"https://…/{z}/{x}/{y}.png"` and confirm the generic `raster-tiled` path renders.
- [ ] Smoke: add `"dem": { "url": "…", "terrain": true }` and confirm hillshade + terrain on MapLibre, warning + no-op on Leaflet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)